### PR TITLE
copy dependencies to target/libs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,9 +5,11 @@
     <artifactId>flume-ng-sinks</artifactId>
     <version>1.4.0</version>
   </parent>
+
   <groupId>org.apache.flume.flume-ng-sinks</groupId>
   <artifactId>flume-ng-kafka-sink</artifactId>
   <version>0.8</version>
+
   <dependencies>
     <dependency>
       <groupId>junit</groupId>
@@ -27,7 +29,7 @@
 		<artifactId>kafka_2.10</artifactId>
 		<version>0.8.0</version>
     </dependency>
-	<dependency>
+    <dependency>
 		<groupId>org.apache.zookeeper</groupId>
 		<artifactId>zookeeper</artifactId>
 		<version>3.4.5</version>
@@ -35,6 +37,52 @@
 	<dependency>
 		<groupId>org.mockito</groupId>
 		<artifactId>mockito-all</artifactId>
-		</dependency>
+	</dependency>
+	<dependency>
+		<groupId>com.codahale.metrics</groupId>
+		<artifactId>metrics-core</artifactId>
+		<version>3.0.0</version>
+	</dependency>
   </dependencies> 
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>2.8</version>
+        <executions>
+          <execution>
+            <id>copy</id>
+            <phase>package</phase>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>com.codahale.metrics</groupId>
+                  <artifactId>metrics-core</artifactId>
+                  <version>3.0.0</version>
+                  <type>jar</type>
+                  <overWrite>false</overWrite>
+                  <outputDirectory>${project.build.directory}/libs</outputDirectory>
+                  <!--<destFileName>optional-new-name.jar</destFileName>-->
+                </artifactItem>
+    			<artifactItem>
+                  <groupId>org.scala-lang</groupId>
+                  <artifactId>scala-library</artifactId>
+                  <version>2.10.3</version>
+                  <type>jar</type>
+                  <overWrite>false</overWrite>
+                  <outputDirectory>${project.build.directory}/libs</outputDirectory>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+           
 </project>


### PR DESCRIPTION
This patch copy dependencies:

metrics-core 3.0.0
scala-library 2.10.3

To target/libs folder.

This patch is related to the issue: https://github.com/buildoop/buildoop/issues/71
